### PR TITLE
use influxdb version 1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   influxdb:
-    image: influxdb:latest
+    image: influxdb:1.8.6
 #    entrypoint: /bin/sh
 #    user: root
     networks:


### PR DESCRIPTION
only running with influxdb version 1.
the tag "latest" will cause to build the influxdb container from version 2 at the time writing this comment. container is throwing permission exceptions in the container logs.