### PR TITLE
fix(Docker) :

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ The script here is an example of a low Virtual User (VU) load test of the excell
 https://swapi.dev/
 
 If you're tinkering with the script, it is just a friendly open source API, be gentle!
+
+
+#### Common errors
+If you encounter the error below:
+
+``` ERRO[0000] The moduleSpecifier "C:/Program Files/Git/script/load.js" couldn't be found on local disk. Make sure that you've specified the right path to the file. If you're running k6 using the Docker image make sure you have mounted the local directory (-v /local/path/:/inside/docker/path) containing your script and modules so that they're accessible by k6 from inside of the container, see https://grafana.com/docs/k6/latest/using-k6/modules/#using ```
+
+Use the command below *(adding double slash)* to run `load.js`:
+
+    ``` docker compose run k6 run //scripts//load.js ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ./grafana-datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml
 
   k6:
-    image: loadimpact/k6:latest
+    image: grafana/k6:latest
 #    entrypoint: /bin/sh
 #    user: root
     networks:
@@ -46,4 +46,5 @@ services:
     environment:
       - K6_OUT=influxdb=http://influxdb:8086/k6
     volumes:
-      - ./scripts:/scripts
+      - ./scripts/load.js:/scripts/load.js
+      - ./scripts/ewoks.js:/scripts/ewoks.js


### PR DESCRIPTION
- Changed k6 image since loadimpact/k6:latest is deprecated. The working image is grafana/k6:latest

- When specifying volumes, add the actual file that you want to mount in the container.